### PR TITLE
Address DeepSource Swift warnings (SW-W1023, SW-W1028)

### DIFF
--- a/BrewBar/AppDelegate.swift
+++ b/BrewBar/AppDelegate.swift
@@ -37,7 +37,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     func applicationWillTerminate(_ aNotification: Notification) {
         appState.cleanup()
+    }
+
+    deinit {
         NotificationCenter.default.removeObserver(self)
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
     }
 
     // MARK: - NSWindowDelegate

--- a/BrewBar/AppState.swift
+++ b/BrewBar/AppState.swift
@@ -172,7 +172,6 @@ class AppState {
     func cleanup() {
         updateTimer?.invalidate()
         updateTimer = nil
-        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: - Timer Scheduling

--- a/BrewBar/Utilities/BrewBarAbout.swift
+++ b/BrewBar/Utilities/BrewBarAbout.swift
@@ -3,7 +3,9 @@ import AppKit
 enum BrewBarAbout {
     /// Standard system About panel with copyright and clickable GitHub link in Credits.
     static func presentStandardPanel() {
-        let url = URL(string: "https://github.com/joshbeard/BrewBar")!
+        guard let url = URL(string: "https://github.com/joshbeard/BrewBar") else {
+            return
+        }
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = .center
         let font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)

--- a/BrewBar/Utilities/LoggingUtility.swift
+++ b/BrewBar/Utilities/LoggingUtility.swift
@@ -10,8 +10,10 @@ class LoggingUtility {
 
     private let logRetentionDays = 5
 
-    static var logDirectoryURL: URL {
-        let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+    static var logDirectoryURL: URL? {
+        guard let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return nil
+        }
         return appSupportURL.appendingPathComponent("BrewBar/Logs", isDirectory: true)
     }
 
@@ -91,7 +93,10 @@ class LoggingUtility {
 
     func cleanupOldLogs() {
         let fileManager = FileManager.default
-        let logsDir = Self.logDirectoryURL
+        guard let logsDir = Self.logDirectoryURL else {
+            print("Unable to resolve log directory for cleanup")
+            return
+        }
 
         // Get the cutoff date (5 days ago)
         let calendar = Calendar.current

--- a/BrewBar/Views/SettingsView.swift
+++ b/BrewBar/Views/SettingsView.swift
@@ -112,7 +112,9 @@ struct GeneralSettingsView: View {
                     }
                 }
                 Button("Open Logs Folder") {
-                    NSWorkspace.shared.open(LoggingUtility.logDirectoryURL)
+                    if let url = LoggingUtility.logDirectoryURL {
+                        NSWorkspace.shared.open(url)
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Avoid force unwraps for the About GitHub URL and Application Support log path
- Unregister NotificationCenter/NSWorkspace observers only in AppDelegate deinit; remove redundant AppState removeObserver from cleanup