### PR TITLE
refactor: address DeepSource warnings

### DIFF
--- a/BrewBar/Utilities/BrewBarUtility.swift
+++ b/BrewBar/Utilities/BrewBarUtility.swift
@@ -27,11 +27,9 @@ class BrewBarUtility {
         ]
 
         // Check if any of the common paths exist
-        for path in commonPaths {
-            if FileManager.default.fileExists(atPath: path) {
-                print("Found brew at: \(path)")
-                return path
-            }
+        for path in commonPaths where FileManager.default.fileExists(atPath: path) {
+            print("Found brew at: \(path)")
+            return path
         }
 
         // Try using /bin/sh to run 'which brew' - more likely to work in Xcode

--- a/BrewBar/Utilities/LoginItemUtility.swift
+++ b/BrewBar/Utilities/LoginItemUtility.swift
@@ -3,7 +3,7 @@ import ServiceManagement
 
 // MARK: - Login Item Helper
 
-class LoginItemUtility {
+enum LoginItemUtility {
     static func setLoginItemEnabled(_ enabled: Bool) {
         if enabled {
             do {

--- a/BrewBar/Views/OutdatedPackagesView.swift
+++ b/BrewBar/Views/OutdatedPackagesView.swift
@@ -595,18 +595,18 @@ struct OutdatedPackagesView: View {
 
     private var filteredOutdatedPackages: [PackageInfo] {
         if searchText.isEmpty { return packagesInfo }
-        return packagesInfo.filter {
-            $0.name.localizedCaseInsensitiveContains(searchText) ||
-                $0.source.localizedCaseInsensitiveContains(searchText)
+        return packagesInfo.filter { package in
+            package.name.localizedCaseInsensitiveContains(searchText) ||
+                package.source.localizedCaseInsensitiveContains(searchText)
         }
     }
 
     private var filteredInstalledPackages: [InstalledPackageInfo] {
         if searchText.isEmpty { return installedPackages }
-        return installedPackages.filter {
-            $0.name.localizedCaseInsensitiveContains(searchText) ||
-                $0.source.localizedCaseInsensitiveContains(searchText) ||
-                $0.version.localizedCaseInsensitiveContains(searchText)
+        return installedPackages.filter { package in
+            package.name.localizedCaseInsensitiveContains(searchText) ||
+                package.source.localizedCaseInsensitiveContains(searchText) ||
+                package.version.localizedCaseInsensitiveContains(searchText)
         }
     }
 

--- a/BrewBarUITests/HomebrewMenubarUITests.swift
+++ b/BrewBarUITests/HomebrewMenubarUITests.swift
@@ -17,19 +17,6 @@ final class BrewBarUITests: XCTestCase {
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    @MainActor
-    func testExample() {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
     @MainActor
     func testLaunchPerformance() {
         // This measures how long it takes to launch your application.


### PR DESCRIPTION
SW-W1031, SW-R1004, SW-R1005, SW-R1030

- Remove empty tearDownWithError and testExample XCTest stubs
- Use named closure arguments in multiline filter closures
- Replace if-inside-for with where clause in brew path lookup
- Change LoginItemUtility from class to caseless enum